### PR TITLE
Fix out-of-bounds access in buildSymbolTable()

### DIFF
--- a/libfsst.cpp
+++ b/libfsst.cpp
@@ -111,6 +111,9 @@ SymbolTable *buildSymbolTable(Counters& counters, vector<u8*> line, size_t len[]
             while (true) {
 	       u8* old = cur;
                counters.count1Inc(pos1);
+               if (cur==end) {
+                  break;
+               }
                // count single symbol (i.e. an option is not extending it)
                if (st->symbols[pos1].length() != 1)
                   counters.count1Inc(*cur);
@@ -130,8 +133,6 @@ SymbolTable *buildSymbolTable(Counters& counters, vector<u8*> line, size_t len[]
                      pos2 = st->byteCodes[word & 0xFF] & FSST_CODE_MASK;
                      cur += 1;
                   }
-               } else if (cur==end) { 
-                  break;
                } else {
                   assert(cur<end);
                   pos2 = st->findLongestSymbol(cur, end);


### PR DESCRIPTION
I'm not entirely confident that this is the only (or even the correct)
change needed, but there's definitely a bug here.

Before this change, the code

```
                if (st->symbols[pos1].length() != 1)
                   counters.count1Inc(*cur);
```

would definitely execute if `cur == end` (confirmed in debugger),
which, I believe, is wrong. Even worse, it can cause the resulting
symbol table to be non-deterministic. I noticed that with the exact
same input data, the symbol table size would sometimes be different.
The non-determinism arises from `makeSample`, which leaves `sampleBuf`
uninitialized after the last sample. The (random) value of the byte
after the last valid data in `sampleBuf` would be added to `counters`
by the above code and cause (random) differences in the generated
symbol table.

I never noticed this until comparing symbol tables that were written
to a file. These files differed in size, even when generated from the
exact same input data.

In the worst case, the code might even read beyond the allocated
`sampleBuf`.