### PR TITLE
added missing unaligned load

### DIFF
--- a/libfsst.cpp
+++ b/libfsst.cpp
@@ -17,12 +17,6 @@
 // You can contact the authors via the FSST source repository : https://github.com/cwida/fsst
 #include "libfsst.hpp"
 
-inline uint64_t fsst_unaligned_load(u8 const* V) {
-  uint64_t Ret;
-  memcpy(&Ret, V, sizeof(uint64_t)); // compiler will generate efficient code (unaligned load, where possible)
-  return Ret;
-}
-
 Symbol concat(Symbol a, Symbol b) {
    Symbol s;
    u32 length = a.length()+b.length();

--- a/libfsst.hpp
+++ b/libfsst.hpp
@@ -56,6 +56,12 @@ typedef uint64_t u64;
 #define FSST_CODE_MAX       (1UL<<FSST_CODE_BITS) /* all bits set: indicating a symbol that has not been assigned a code yet */
 #define FSST_CODE_MASK      (FSST_CODE_MAX-1UL)   /* all bits set: indicating a symbol that has not been assigned a code yet */
 
+inline uint64_t fsst_unaligned_load(u8 const* V) {
+    uint64_t Ret;
+    memcpy(&Ret, V, sizeof(uint64_t)); // compiler will generate efficient code (unaligned load, where possible)
+    return Ret;
+}
+
 struct Symbol {
    static const unsigned maxLength = 8;
 
@@ -373,7 +379,7 @@ struct Counters {
    }
    u32 count1GetNext(u32 &pos1) { // note: we will advance pos1 to the next nonzero counter in register range
       // read 16-bits single symbol counter, split into two 8-bits numbers (count1Low, count1High), while skipping over zeros
-      u64 high = *(u64*) &count1High[pos1]; // note: this reads 8 subsequent counters [pos1..pos1+7]
+      u64 high = fsst_unaligned_load(&count1High[pos1]); // note: this reads 8 subsequent counters [pos1..pos1+7]
 
       u32 zero = high?(__builtin_ctzl(high)>>3):7UL; // number of zero bytes
       high = (high >> (zero << 3)) & 255; // advance to nonzero counter
@@ -386,7 +392,7 @@ struct Counters {
    }
    u32 count2GetNext(u32 pos1, u32 &pos2) { // note: we will advance pos2 to the next nonzero counter in register range
       // read 12-bits pairwise symbol counter, split into low 8-bits and high 4-bits number while skipping over zeros
-      u64 high = *(u64*) &count2High[pos1][pos2>>1]; // note: this reads 16 subsequent counters [pos2..pos2+15]
+      u64 high = fsst_unaligned_load(&count2High[pos1][pos2>>1]); // note: this reads 16 subsequent counters [pos2..pos2+15]
       high >>= ((pos2&1) << 2); // odd pos2: ignore the lowest 4 bits & we see only 15 counters
 
       u32 zero = high?(__builtin_ctzl(high)>>2):(15UL-(pos2&1UL)); // number of zero 4-bits counters


### PR DESCRIPTION
In DuckDB CI we were getting alignment errors during tests on Linux in debug mode.
```
2022-11-28T17:20:18.2435813Z --------------------
2022-11-28T17:20:18.2435996Z STDERR
2022-11-28T17:20:18.2436652Z --------------------
2022-11-28T17:20:18.2436782Z 
2022-11-28T17:20:18.2437841Z /home/runner/work/duckdb/duckdb/third_party/fsst/libfsst.hpp:383:8: runtime error: load of misaligned address 0x7fd6293f6811 for type 'u64', which requires 8 byte alignment
2022-11-28T17:20:18.2438241Z 0x7fd6293f6811: note: pointer points here
2022-11-28T17:20:18.2438531Z  00 00 00  ff 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00
```
