### PR TITLE
Zero initialize buffer to avoid uninitialized reads

### DIFF
--- a/libfsst.cpp
+++ b/libfsst.cpp
@@ -382,8 +382,7 @@ static inline size_t compressBulk(SymbolTable &symbolTable, size_t nlines, size_
    size_t curLine, suffixLim = symbolTable.suffixLim;
    u8 byteLim = symbolTable.nSymbols + symbolTable.zeroTerminated - symbolTable.lenHisto[0];
 
-   u8 buf[512+8]; /* +8 sentinel is to avoid 8-byte unaligned-loads going beyond 511 out-of-bounds */
-   memset(buf, 0, 520); /* and initialize the sentinal bytes */ 
+   u8 buf[512+8] = {}; /* +8 sentinel is to avoid 8-byte unaligned-loads going beyond 511 out-of-bounds */
 
    // three variants are possible. dead code falls away since the bool arguments are constants
    auto compressVariant = [&](bool noSuffixOpt, bool avoidBranch) {


### PR DESCRIPTION
Found with a MemorySanitizer-enabled build, and signaled to duckdb here: https://github.com/duckdb/duckdb/issues/7433.

The issue happens IF the buffer has not been completely filled AND reading past the currently filled range.

Fix is zero initializing the buffer, that has negligible amortized cost (being done outside the main loop).