### PR TITLE
Make `fsst_compress` and `fsst_decompress` const-correct

### DIFF
--- a/fsst.cpp
+++ b/fsst.cpp
@@ -168,7 +168,7 @@ int main(int argc, char* argv[]) {
           unsigned char tmp[FSST_MAXHEADER];
           fsst_encoder_t *encoder = fsst_create(1, &srcLen[swap], &srcBuf[swap], 0);
           size_t hdr = fsst_export(encoder, tmp);
-          if (fsst_compress(encoder, 1, &srcLen[swap], &srcBuf[swap], FSST_MEMBUF*2, dstMem[swap]+FSST_MAXHEADER+3,
+          if (fsst_compress(encoder, 1, &srcLen[swap], const_cast<const unsigned char**>(&srcBuf[swap]), FSST_MEMBUF*2, dstMem[swap]+FSST_MAXHEADER+3,
                                        &dstLen[swap], &dstBuf[swap]) < 1) return -1;
           dstLen[swap] += 3 + hdr;
           dstBuf[swap] -= 3 + hdr;

--- a/fsst.h
+++ b/fsst.h
@@ -80,7 +80,7 @@ typedef void* fsst_encoder_t; /* opaque type - it wraps around a rather large (~
 typedef struct {
    unsigned long long version;     /* version id */
    unsigned char zeroTerminated;   /* terminator is a single-byte code that does not appear in longer symbols */
-   unsigned char len[255];         /* len[x] is the byte-lengths of the symbol x (1 < len[x] <= 8). */
+   unsigned char len[255];         /* len[x] is the byte-length of the symbol x (1 < len[x] <= 8). */
    unsigned long long symbol[255]; /* symbol[x] contains in LITTLE_ENDIAN the bytesequence that code x represents (0 <= x < 255). */ 
 } fsst_decoder_t;
 

--- a/fsst.h
+++ b/fsst.h
@@ -80,7 +80,7 @@ typedef void* fsst_encoder_t; /* opaque type - it wraps around a rather large (~
 typedef struct {
    unsigned long long version;     /* version id */
    unsigned char zeroTerminated;   /* terminator is a single-byte code that does not appear in longer symbols */
-   unsigned char len[255];         /* len[x] is the byte-length of the symbol x (1 < len[x] <= 8). */
+   unsigned char len[255];         /* len[x] is the byte-lengths of the symbol x (1 < len[x] <= 8). */
    unsigned long long symbol[255]; /* symbol[x] contains in LITTLE_ENDIAN the bytesequence that code x represents (0 <= x < 255). */ 
 } fsst_decoder_t;
 
@@ -131,8 +131,8 @@ size_t                      /* OUT: the number of compressed strings (<=n) that 
 fsst_compress(
    fsst_encoder_t *encoder, /* IN: encoder obtained from fsst_create(). */
    size_t nstrings,         /* IN: number of strings in batch to compress. */
-   size_t lenIn[],          /* IN: byte-lengths of the inputs */
-   unsigned char *strIn[],  /* IN: input string start pointers. */
+   const size_t lenIn[],          /* IN: byte-lengths of the inputs */
+   const unsigned char *strIn[],  /* IN: input string start pointers. */
    size_t outsize,          /* IN: byte-length of output buffer. */
    unsigned char *output,   /* OUT: memory buffer to put the compressed strings in (one after the other). */
    size_t lenOut[],         /* OUT: byte-lengths of the compressed strings. */
@@ -142,9 +142,9 @@ fsst_compress(
 /* Decompress a single string, inlined for speed. */
 inline size_t /* OUT: bytesize of the decompressed string. If > size, the decoded output is truncated to size. */
 fsst_decompress(
-   fsst_decoder_t *decoder,  /* IN: use this symbol table for compression. */
+   const fsst_decoder_t *decoder,  /* IN: use this symbol table for compression. */
    size_t lenIn,             /* IN: byte-length of compressed string. */
-   unsigned char *strIn,     /* IN: compressed string. */
+   const unsigned char *strIn,     /* IN: compressed string. */
    size_t size,              /* IN: byte-length of output buffer. */
    unsigned char *output     /* OUT: memory buffer to put the decompressed string in. */
 ) {

--- a/fsst12.h
+++ b/fsst12.h
@@ -113,8 +113,8 @@ unsigned long               /* OUT: the number of compressed strings (<=n) that 
 fsst_compress(
    fsst_encoder_t *encoder,  /* IN: encoder obtained from fsst_create(). */
    unsigned long nstrings,  /* IN: number of strings in batch to compress. */
-   unsigned long lenIn[],   /* IN: byte-lengths of the inputs */
-   unsigned char *strIn[],  /* IN: input string start pointers. */
+   const unsigned long lenIn[],   /* IN: byte-lengths of the inputs */
+   const unsigned char *strIn[],  /* IN: input string start pointers. */
    unsigned long outsize,   /* IN: byte-length of output buffer. */
    unsigned char *output,   /* OUT: memory buffer to put the compressed strings in (one after the other). */
    unsigned long lenOut[],   /* OUT: byte-lengths of the compressed strings. */

--- a/fsst12.h
+++ b/fsst12.h
@@ -124,9 +124,9 @@ fsst_compress(
 /* Decompress a single string, inlined for speed. */
 inline unsigned long        /* OUT: bytesize of the decompressed string. If > size, the decoded output is truncated to size. */
 fsst_decompress(
-   fsst_decoder_t *decoder,  /* IN: use this dictionary for compression. */
+   const fsst_decoder_t *decoder,  /* IN: use this dictionary for compression. */
    unsigned long lenIn,     /* IN: byte-length of compressed string. */
-   unsigned char *strIn,    /* IN: compressed string. */
+   const unsigned char *strIn,    /* IN: compressed string. */
    unsigned long size,      /* IN: byte-length of output buffer. */
    unsigned char *output    /* OUT: memory buffer to put the decompressed string in. */
 ) {

--- a/libfsst.cpp
+++ b/libfsst.cpp
@@ -55,7 +55,6 @@ std::ostream& operator<<(std::ostream& out, const Symbol& s) {
       out << s.val.str[i];
    return out;
 }
-static u64 iter = 0;
 
 SymbolTable *buildSymbolTable(Counters& counters, vector<u8*> line, size_t len[], bool zeroTerminated=false) {
    SymbolTable *st = new SymbolTable(), *bestTable = new SymbolTable();
@@ -240,7 +239,7 @@ SymbolTable *buildSymbolTable(Counters& counters, vector<u8*> line, size_t len[]
    return bestTable;
 }
 
-static inline size_t compressSIMD(SymbolTable &symbolTable, u8* symbolBase, size_t nlines, size_t len[], u8* line[], size_t size, u8* dst, size_t lenOut[], u8* strOut[], int unroll) {
+static inline size_t compressSIMD(SymbolTable &symbolTable, u8* symbolBase, size_t nlines, const size_t len[], const u8* line[], size_t size, u8* dst, size_t lenOut[], u8* strOut[], int unroll) {
    size_t curLine = 0, inOff = 0, outOff = 0, batchPos = 0, empty = 0, budget = size;
    u8 *lim = dst + size, *codeBase = symbolBase + (1<<18); // 512KB temp space for compressing 512 strings 
    SIMDjob input[512];  // combined offsets of input strings (cur,end), and string #id (pos) and output (dst) pointer
@@ -375,8 +374,8 @@ static inline size_t compressSIMD(SymbolTable &symbolTable, u8* symbolBase, size
 
 
 // optimized adaptive *scalar* compression method
-static inline size_t compressBulk(SymbolTable &symbolTable, size_t nlines, size_t lenIn[], u8* strIn[], size_t size, u8* out, size_t lenOut[], u8* strOut[], bool noSuffixOpt, bool avoidBranch) {
-   u8 *cur = NULL, *end =  NULL, *lim = out + size;
+static inline size_t compressBulk(SymbolTable &symbolTable, size_t nlines, const size_t lenIn[], const u8* strIn[], size_t size, u8* out, size_t lenOut[], u8* strOut[], bool noSuffixOpt, bool avoidBranch) {
+   const u8 *cur = NULL, *end =  NULL, *lim = out + size;
    size_t curLine, suffixLim = symbolTable.suffixLim;
    u8 byteLim = symbolTable.nSymbols + symbolTable.zeroTerminated - symbolTable.lenHisto[0];
 
@@ -586,7 +585,7 @@ extern "C" u32 fsst_import(fsst_decoder_t *decoder, u8 *buf) {
 }
 
 // runtime check for simd
-inline size_t _compressImpl(Encoder *e, size_t nlines, size_t lenIn[], u8 *strIn[], size_t size, u8 *output, size_t *lenOut, u8 *strOut[], bool noSuffixOpt, bool avoidBranch, int simd) {
+inline size_t _compressImpl(Encoder *e, size_t nlines, const size_t lenIn[], const u8 *strIn[], size_t size, u8 *output, size_t *lenOut, u8 *strOut[], bool noSuffixOpt, bool avoidBranch, int simd) {
 #ifndef NONOPT_FSST
    if (simd && fsst_hasAVX512())
       return compressSIMD(*e->symbolTable, e->simdbuf, nlines, lenIn, strIn, size, output, lenOut, strOut, simd);
@@ -594,12 +593,12 @@ inline size_t _compressImpl(Encoder *e, size_t nlines, size_t lenIn[], u8 *strIn
    (void) simd;
    return compressBulk(*e->symbolTable, nlines, lenIn, strIn, size, output, lenOut, strOut, noSuffixOpt, avoidBranch);
 }
-size_t compressImpl(Encoder *e, size_t nlines, size_t lenIn[], u8 *strIn[], size_t size, u8 *output, size_t *lenOut, u8 *strOut[], bool noSuffixOpt, bool avoidBranch, int simd) {
+size_t compressImpl(Encoder *e, size_t nlines, const size_t lenIn[], const u8 *strIn[], size_t size, u8 *output, size_t *lenOut, u8 *strOut[], bool noSuffixOpt, bool avoidBranch, int simd) {
    return _compressImpl(e, nlines, lenIn, strIn, size, output, lenOut, strOut, noSuffixOpt, avoidBranch, simd);
 }
 
 // adaptive choosing of scalar compression method based on symbol length histogram 
-inline size_t _compressAuto(Encoder *e, size_t nlines, size_t lenIn[], u8 *strIn[], size_t size, u8 *output, size_t *lenOut, u8 *strOut[], int simd) {
+inline size_t _compressAuto(Encoder *e, size_t nlines, const size_t lenIn[], const u8 *strIn[], size_t size, u8 *output, size_t *lenOut, u8 *strOut[], int simd) {
    bool avoidBranch = false, noSuffixOpt = false;
    if (100*e->symbolTable->lenHisto[1] > 65*e->symbolTable->nSymbols && 100*e->symbolTable->suffixLim > 95*e->symbolTable->lenHisto[1]) {
       noSuffixOpt = true;
@@ -610,12 +609,12 @@ inline size_t _compressAuto(Encoder *e, size_t nlines, size_t lenIn[], u8 *strIn
    }
    return _compressImpl(e, nlines, lenIn, strIn, size, output, lenOut, strOut, noSuffixOpt, avoidBranch, simd);
 }
-size_t compressAuto(Encoder *e, size_t nlines, size_t lenIn[], u8 *strIn[], size_t size, u8 *output, size_t *lenOut, u8 *strOut[], int simd) {
+size_t compressAuto(Encoder *e, size_t nlines, const size_t lenIn[], const u8 *strIn[], size_t size, u8 *output, size_t *lenOut, u8 *strOut[], int simd) {
    return _compressAuto(e, nlines, lenIn, strIn, size, output, lenOut, strOut, simd);
 }
 
 // the main compression function (everything automatic)
-extern "C" size_t fsst_compress(fsst_encoder_t *encoder, size_t nlines, size_t lenIn[], u8 *strIn[], size_t size, u8 *output, size_t *lenOut, u8 *strOut[]) {
+extern "C" size_t fsst_compress(fsst_encoder_t *encoder, size_t nlines, const size_t lenIn[], const u8 *strIn[], size_t size, u8 *output, size_t *lenOut, u8 *strOut[]) {
    // to be faster than scalar, simd needs 64 lines or more of length >=12; or fewer lines, but big ones (totLen > 32KB)
    size_t totLen = accumulate(lenIn, lenIn+nlines, 0);
    int simd = totLen > nlines*12 && (nlines > 64 || totLen > (size_t) 1<<15); 

--- a/libfsst12.hpp
+++ b/libfsst12.hpp
@@ -83,7 +83,7 @@ struct Symbol {
       }
    }
    explicit Symbol(const char* begin, const char* end) : Symbol(begin, end-begin) {}
-   explicit Symbol(u8* begin, u8* end) : Symbol((const char*)begin, end-begin) {}
+   explicit Symbol(const u8* begin, const u8* end) : Symbol((const char*)begin, end-begin) {}
    void set_code_len(u32 code, u32 len) { gcl = (len<<28)|(code<<16)|((8-len)*8); }
 
    u8 length() const { return gcl >> 28; }


### PR DESCRIPTION
Previously, the input parameters to `fsst_compress` and `fsst_compress` were passed in as `size_t[]` and `unsigned char*[]` respectively although these parameters are never modified. This commit changes these types to `const size_t[]` and `const unsigned char*[]`. For the same reason, the decoder is now passed as a `const fsst_decoder_t*` to the `fsst_decompress` function (it previously was a `fsst_deocder_t*`.

This commit also removes three unused variables, that lead to compiler warnings.