### PR TITLE
Removed unnecessary array that triggered Buffer Overflow

### DIFF
--- a/libfsst.cpp
+++ b/libfsst.cpp
@@ -465,7 +465,6 @@ vector<u8*> makeSample(u8* sampleBuf, u8* strIn[], size_t **lenRef, size_t nline
    } else {
       size_t sampleRnd = FSST_HASH(4637947);
       u8* sampleLim = sampleBuf + FSST_SAMPLETARGET;
-      size_t *sampleLen = *lenRef = new size_t[nlines + FSST_SAMPLEMAXSZ/FSST_SAMPLELINE];
 
       while(sampleBuf < sampleLim) {
          // choose a non-empty line
@@ -483,7 +482,7 @@ vector<u8*> makeSample(u8* sampleBuf, u8* strIn[], size_t **lenRef, size_t nline
          size_t len = min(lenIn[linenr]-chunk,FSST_SAMPLELINE);
          memcpy(sampleBuf, strIn[linenr]+chunk, len);
          sample.push_back(sampleBuf);
-         sampleBuf += *sampleLen++ = len;
+         sampleBuf += len;
       }
    }
    return sample;


### PR DESCRIPTION
Hi, after working with your lib i discovered a buffer overflow with the input data attached in the make_sample function. After investigating it, I discovered that the part of code which triggered the Buffer Overflow isn't of any use. 

Reason for Buffer Overflow: 
sampleLen gets initialized with a fixed size of nlines + FSST_SAMPLEMAXSZ/FSST_SAMPLELINE; what does not get taken into account is that not all lines get put in the sampleBuffer evenly distributed (so a few lines get put into the sampleBuffer multiple times and a few aren't inserted once). This can create a buffer overflow although the totalLen >= FSST_SAMPLETARGET (in my example that is the case). The buffer overflow happens in the sampleLen-array; this array isn't really used in the makeSample-method; therefore i propose to remove it. This also removes the case for a buffer-overflow. 

[physicians.txt](https://github.com/cwida/fsst/files/14524859/physicians.txt)
