### PR TITLE
Also make `fsst_create` const-correct

### DIFF
--- a/fsst.cpp
+++ b/fsst.cpp
@@ -165,12 +165,14 @@ int main(int argc, char* argv[]) {
           size_t hdr = fsst_import(&decoder, srcBuf[swap]);
           dstLen[swap] = fsst_decompress(&decoder, srcLen[swap] - hdr, srcBuf[swap] + hdr, FSST_MEMBUF, dstBuf[swap] = dstMem[swap]);
       } else {
-          unsigned char tmp[FSST_MAXHEADER];
-          fsst_encoder_t *encoder = fsst_create(1, &srcLen[swap], &srcBuf[swap], 0);
-          size_t hdr = fsst_export(encoder, tmp);
-          if (fsst_compress(encoder, 1, &srcLen[swap], const_cast<const unsigned char**>(&srcBuf[swap]), FSST_MEMBUF*2, dstMem[swap]+FSST_MAXHEADER+3,
-                                       &dstLen[swap], &dstBuf[swap]) < 1) return -1;
-          dstLen[swap] += 3 + hdr;
+         unsigned char tmp[FSST_MAXHEADER];
+         fsst_encoder_t* encoder = fsst_create(1, &srcLen[swap], const_cast<const unsigned char **>(&srcBuf[swap]), 0);
+         size_t hdr = fsst_export(encoder, tmp);
+         if (fsst_compress(encoder, 1, &srcLen[swap], const_cast<const unsigned char **>(&srcBuf[swap]),
+                           FSST_MEMBUF * 2, dstMem[swap] + FSST_MAXHEADER + 3,
+                           &dstLen[swap], &dstBuf[swap]) < 1)
+            return -1;
+         dstLen[swap] += 3 + hdr;
           dstBuf[swap] -= 3 + hdr;
           SERIALIZE(dstLen[swap],dstBuf[swap]); // block starts with size
           copy(tmp, tmp+hdr, dstBuf[swap]+3); // then the header (followed by the compressed bytes which are already there)

--- a/fsst.h
+++ b/fsst.h
@@ -88,8 +88,8 @@ typedef struct {
 fsst_encoder_t*  
 fsst_create(
    size_t n,         /* IN: number of strings in batch to sample from. */
-   size_t lenIn[],   /* IN: byte-lengths of the inputs */
-   unsigned char *strIn[],  /* IN: string start pointers. */
+   const size_t lenIn[],   /* IN: byte-lengths of the inputs */
+   const unsigned char *strIn[],  /* IN: string start pointers. */
    int zeroTerminated       /* IN: whether input strings are zero-terminated. If so, encoded strings are as well (i.e. symbol[0]=""). */
 );
 

--- a/fsst12.h
+++ b/fsst12.h
@@ -70,8 +70,8 @@ typedef struct {
 fsst_encoder_t*  
 fsst_create(
    unsigned long n,         /* IN: number of strings in batch to sample from. */
-   unsigned long lenIn[],   /* IN: byte-lengths of the inputs */
-   unsigned char *strIn[],  /* IN: string start pointers. */
+   const unsigned long lenIn[],   /* IN: byte-lengths of the inputs */
+   const unsigned char *strIn[],  /* IN: string start pointers. */
    int dummy
 );
 

--- a/libfsst.hpp
+++ b/libfsst.hpp
@@ -75,7 +75,7 @@ struct Symbol {
 
    explicit Symbol(u8 c, u16 code) : icl((1<<28)|(code<<16)|56) { val.num = c; } // single-char symbol
    explicit Symbol(const char* begin, const char* end) : Symbol(begin, (u32) (end-begin)) {}
-   explicit Symbol(u8* begin, u8* end) : Symbol((const char*)begin, (u32) (end-begin)) {}
+   explicit Symbol(const u8* begin, const u8* end) : Symbol((const char*)begin, (u32) (end-begin)) {}
    explicit Symbol(const char* input, u32 len) {
       val.num = 0;
       if (len>=8) {
@@ -244,7 +244,7 @@ struct SymbolTable {
       }
       return byteCodes[s.first()] & FSST_CODE_MASK;
    }
-   u16 findLongestSymbol(u8* cur, u8* end) const {
+   u16 findLongestSymbol(const u8* cur, const u8* end) const {
       return findLongestSymbol(Symbol(cur,end)); // represent the string as a temporary symbol
    }
 


### PR DESCRIPTION
In my previous PR I missed the `fsst_create` function, which can also take its input strings as pointers to const.