### PR TITLE
FSST12: Limit Symbol Length to 8

### DIFF
--- a/libfsst12.hpp
+++ b/libfsst12.hpp
@@ -77,6 +77,7 @@ struct Symbol {
          *(u64*) symbol = 0;
          for(u32 i=0; i<len; i++) symbol[i] = input[i];
       } else {
+         len = 8;
          *(u64*) symbol = *(u64*) input;
       }
       set_code_len(FSST_CODE_MASK, len);


### PR DESCRIPTION
FSST12 was crashing when Symbol was being constructed for larger inputs, since the `len` could be larger than 8. This was particularly the case for `compressCount` function, which was calling `Symbol(cur, end)` where `cur` and `end` are pointers to the input string start and end (can be a lot longer than 8 bytes).

This PR fixes this issue similar to the original FSST: In Symbol constructor, `len` is set to 8 if it is larger.