### PR TITLE
fix: const-correctness in fsst_import()

### DIFF
--- a/fsst.h
+++ b/fsst.h
@@ -116,7 +116,7 @@ fsst_destroy(fsst_encoder_t*);
 unsigned int                /* OUT: number of bytes consumed in buf (0 on failure). */
 fsst_import(
    fsst_decoder_t *decoder, /* IN: this symbol table will be overwritten. */ 
-   unsigned char *buf       /* OUT: pointer to a byte-buffer where fsst_export() serialized this symbol table. */
+   unsigned char const *buf /* IN: pointer to a byte-buffer where fsst_export() serialized this symbol table. */
 ); 
 
 /* Return a decoder structure from an encoder. */

--- a/libfsst.cpp
+++ b/libfsst.cpp
@@ -549,7 +549,7 @@ extern "C" u32 fsst_export(fsst_encoder_t *encoder, u8 *buf) {
 
 #define FSST_CORRUPT 32774747032022883 /* 7-byte number in little endian containing "corrupt" */
 
-extern "C" u32 fsst_import(fsst_decoder_t *decoder, u8 *buf) {
+extern "C" u32 fsst_import(fsst_decoder_t *decoder, u8 const *buf) {
    u64 version = 0;
    u32 code, pos = 17;
    u8 lenHisto[8];


### PR DESCRIPTION
The buffer argument to `fsst_import()` is an input argument and thus the pointer should be `const`.