### PR TITLE
Include missing headers for compatibility with GCC 15

### DIFF
--- a/libfsst.hpp
+++ b/libfsst.hpp
@@ -17,6 +17,7 @@
 // You can contact the authors via the FSST source repository : https://github.com/cwida/fsst 
 #include <algorithm>
 #include <cassert>
+#include <cstdint>
 #include <cstring>
 #include <fstream>
 #include <iostream>

--- a/libfsst12.hpp
+++ b/libfsst12.hpp
@@ -17,6 +17,7 @@
 // You can contact the authors via the FSST source repository : https://github.com/cwida/fsst 
 #include <algorithm>
 #include <cassert>
+#include <cstdint>
 #include <cstring>
 #include <fstream>
 #include <iostream>


### PR DESCRIPTION
cstdint needs to be included explicitly since GCC 15.
https://gcc.gnu.org/gcc-15/porting_to.html