### PR TITLE
Correctly detect the situation where we have 3 bytes remaining

### DIFF
--- a/fsst.h
+++ b/fsst.h
@@ -177,7 +177,7 @@ fsst_decompress(
          }
       }
    }
-   if (posOut+24 <= size) { // handle the possibly 3 last bytes without a loop
+   if (posOut+32 <= size) { // handle the possibly 3 last bytes without a loop
       if (posIn+2 <= lenIn) { 
 	 strOut[posOut] = strIn[posIn+1]; 
          if (strIn[posIn] != FSST_ESC) {


### PR DESCRIPTION
The loop above defines the following condition:

```cpp
while (posOut+32 <= size && posIn+4 <= lenIn)
```

i.e. we break either if we are reaching the end of the output buffer, OR we only `<= 3` bytes remaining in the input buffer.

We then check if we have `<= 3` bytes remaining as follows:

```cpp
if (posOut+24 <= size) { // handle the possibly 3 last bytes without a loop
```

This is incorrect, it should be the same as the condition above. 

(corresponding fix in duckdb here - https://github.com/duckdb/duckdb/pull/16688)