### PR TITLE
Bump `cmake_minimum_required` version to 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(fsst)
 


### PR DESCRIPTION
Since cmake's recent update to version 4.0, projects using `fsst` get the following error message:

```
CMake Error at build/_deps/fsst-src/CMakeLists.txt:1 (cmake_minimum_required):
Compatibility with CMake < 3.5 has been removed from CMake.

Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
to tell CMake that the project requires at least <min> but has been updated
to work with policies introduced by <max> or earlier.

Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
```

Bumping the `cmake_minimum_required` version to 3.5 would be an easy fix.