### PR TITLE
fix: set `NONOPT_FSST` for 32-bit platforms (fixes #37)

### DIFF
--- a/libfsst.cpp
+++ b/libfsst.cpp
@@ -242,6 +242,7 @@ SymbolTable *buildSymbolTable(Counters& counters, vector<const u8*> line, const 
    return bestTable;
 }
 
+#ifndef NONOPT_FSST
 static inline size_t compressSIMD(SymbolTable &symbolTable, u8* symbolBase, size_t nlines, const size_t len[], const u8* line[], size_t size, u8* dst, size_t lenOut[], u8* strOut[], int unroll) {
    size_t curLine = 0, inOff = 0, outOff = 0, batchPos = 0, empty = 0, budget = size;
    u8 *lim = dst + size, *codeBase = symbolBase + (1<<18); // 512KB temp space for compressing 512 strings 
@@ -374,7 +375,7 @@ static inline size_t compressSIMD(SymbolTable &symbolTable, u8* symbolBase, size
    }
    return curLine;
 }
-
+#endif
 
 // optimized adaptive *scalar* compression method
 static inline size_t compressBulk(SymbolTable &symbolTable, size_t nlines, const size_t lenIn[], const u8* strIn[], size_t size, u8* out, size_t lenOut[], u8* strOut[], bool noSuffixOpt, bool avoidBranch) {

--- a/libfsst.hpp
+++ b/libfsst.hpp
@@ -44,6 +44,11 @@ typedef uint32_t u32;
 typedef uint64_t u64;
 }  // namespace libfsst
 
+#if UINTPTR_MAX == 0xffffffffU
+// We're on a 32-bit platform
+#define NONOPT_FSST
+#endif
+
 #define FSST_ENDIAN_MARKER ((u64) 1)
 #define FSST_VERSION_20190218 20190218
 #define FSST_VERSION ((u64) FSST_VERSION_20190218)


### PR DESCRIPTION
The optimized code paths for (at least) `count1GetNext()` don't work correctly on 32-bit platforms (at least on ARM, with gcc), presumably due to using `__builtin_ctzl()` on a 64-bit value. This resulted in `buildSymbolTable()` being stuck in an endless loop.

This change simply disables the optimized code paths if a 32-bit platform is detected.