### PR TITLE
Add basic CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v5
+    
+    - name: Configure CMake
+      run: |
+        cmake -B build -S .
+    
+    - name: Build
+      run: |
+        cmake --build build --config Release
+


### PR DESCRIPTION
This PR adds a GitHub CI workflow that builds the project.

I can contribute additional CI coverage, such as building the project on other platforms and running tests as well as a release workflow.

You can see here that it passes: https://github.com/louwers/fsst/actions/runs/19102448516

Once merged it will run for all pull requests and pushes to the `master` branch.