### PR TITLE
feat: always use 64-bit hash computation

### DIFF
--- a/libfsst.cpp
+++ b/libfsst.cpp
@@ -467,7 +467,7 @@ vector<const u8*> makeSample(u8* sampleBuf, const u8* strIn[], const size_t **le
       for(size_t i=0; i<nlines; i++) 
          sample.push_back(strIn[i]);
    } else {
-      size_t sampleRnd = FSST_HASH(4637947);
+      u64 sampleRnd = FSST_HASH(4637947);
       const u8* sampleLim = sampleBuf + FSST_SAMPLETARGET;
       size_t *sampleLen =  new size_t[nlines + FSST_SAMPLEMAXSZ/FSST_SAMPLELINE];
       *lenRef = sampleLen;

--- a/libfsst.hpp
+++ b/libfsst.hpp
@@ -116,10 +116,10 @@ struct Symbol {
    u16 first2() const { assert( length() >= 2); return 0xFFFF & load_num(); }
 
 #define FSST_HASH_LOG2SIZE 10 
-#define FSST_HASH_PRIME 2971215073LL
+#define FSST_HASH_PRIME 2971215073ULL
 #define FSST_SHIFT 15
 #define FSST_HASH(w) (((w)*FSST_HASH_PRIME)^(((w)*FSST_HASH_PRIME)>>FSST_SHIFT))
-   size_t hash() const { size_t v = 0xFFFFFF & load_num(); return FSST_HASH(v); } // hash on the next 3 bytes
+   u64 hash() const { u64 v = 0xFFFFFF & load_num(); return FSST_HASH(v); } // hash on the next 3 bytes
 };
 
 // Symbol that can be put in a queue, ordered on gain


### PR DESCRIPTION
This ensures consistent behaviour between architectures with different word sizes. On 64-bit architectures, this change has no impact.